### PR TITLE
fix(ci-calls): remove checkers calls dependency on CPPFLAGS

### DIFF
--- a/ci.mk
+++ b/ci.mk
@@ -22,8 +22,8 @@ gitlint:
 # Checks if the provided source file have a SPDX license identifier following
 # the provided SPDX license expriession.
 #    make license-check
-# @param string of SPDX expression of the allowed license for the files defined 
-#     in the second param
+# @param string of SPDX expression of the allowed license for the files defined
+#    in the second param
 # @param space-separated list of source files (any kind)
 # @example $(call ci, license, "Apache-2.0 OR MIT", file1.c file.rs file.h file.mk)
 
@@ -111,9 +111,9 @@ endef
 #    make tidy
 # @pre the make variable `clang-arch` must be defined if using the tidy rule
 #    with a valid target fot the clang compiler
-# @param1 a single space-separated list of C files (header or source)
-# @param2 a list of pre-processor options, specially the include directory
-# paths
+# @param files a single space-separated list of C files (header or source)
+# @param paths a list of pre-processor options, specially the include
+#    directory paths
 # @example $(call ci, tidy, file1.c file2.c file3.h, -I/my/include/dir/inc)
 
 tidy:
@@ -133,8 +133,8 @@ endef
 # Cppcheck static-analyzer
 # Run it by:
 #    make cppcheck
-# @param1 a single space-separated list of C files (header or source)
-# @param2 a list of preprocessor flags, including header files root path
+# @param files a single space-separated list of C files (header or source)
+# @param headers a list of preprocessor flags, including header files root path
 # @example $(call ci, cppcheck, file1.c file2.c file3.h, -I/my/include/dir/inc)
 
 cppcheck_type_cfg:=$(ci_dir)/.cppcheck-types.cfg
@@ -171,9 +171,9 @@ endef
 #    make misra-check
 # @pre MISRA checker rules assume your repository as a misra folder in the
 #    top-level directories with the records and permits subdirectories (see doc).
-# @param1 space separated list of C source files
-# @param2 space separated list of C header files
-# @param3 a list of preprocessor flags, including header files root path
+# @param cfiles space separated list of C source files
+# @param hfiles space separated list of C header files
+# @param paths a list of preprocessor flags, including header files root path
 # @example $(call ci, misra, file1.c file2.c, file3.h, -I/my/include/dir/inc)
 
 misra_ci_dir:=$(ci_dir)/misra

--- a/ci.mk
+++ b/ci.mk
@@ -196,9 +196,9 @@ define cppcheck_misra_addon
 }"
 endef
 
-cppcheck_misra_flags:= --quiet --enable=all --error-exitcode=1 \
+cppcheck_misra_flags= --quiet --enable=all --error-exitcode=1 \
 	--library=$(cppcheck_type_cfg) --addon=$(cppcheck_misra_addon) \
-	--suppressions-list=$(misra_suppresions)
+	--suppressions-list=$(misra_suppresions) $(_misra_flags)
 zephyr_coding_guidelines:=https://raw.githubusercontent.com/zephyrproject-rtos/zephyr/main/doc/contribute/coding_guidelines/index.rst
 
 ifeq ($(MISRA_C2012_GUIDELINES),)
@@ -218,7 +218,7 @@ $(misra_suppresions): $(misra_cppcheck_supressions) $(misra_deviation_suppressio
 	@cat $^ > $@
 
 misra-check: $(misra_rules) $(cppcheck_type_cfg) $(misra_suppresions)
-	@$(CPPCHECK) $(cppcheck_misra_flags) $(_misra_flags) $(_misra_c_files)
+	@$(CPPCHECK) $(cppcheck_misra_flags) $(_misra_c_files)
 
 misra-clean:
 	-rm -f $(misra_rules) $(misra_suppresions) $(misra_deviation_suppressions)

--- a/ci.mk
+++ b/ci.mk
@@ -112,9 +112,9 @@ endef
 # @pre the make variable `clang-arch` must be defined if using the tidy rule
 #    with a valid target fot the clang compiler
 # @param1 a single space-separated list of C files (header or source)
-# @param2 a list of pre-processor options, specially the include directory 
-# -paths (e.g -I/my/include/dir/inc)
-# @example $(call ci, tidy, file1.c file2.c file3.h)
+# @param2 a list of pre-processor options, specially the include directory
+# paths
+# @example $(call ci, tidy, file1.c file2.c file3.h, -I/my/include/dir/inc)
 
 tidy:
 	@$(CLANG-TIDY) --config-file=$(ci_dir)/.clang-tidy $(_tidy_files) -- \
@@ -134,8 +134,8 @@ endef
 # Run it by:
 #    make cppcheck
 # @param1 a single space-separated list of C files (header or source)
-# @param2 a list of preprocessor flags, including header files root path 
-# @example $(call ci, cppcheck, file1.c file2.c file3.h)
+# @param2 a list of preprocessor flags, including header files root path
+# @example $(call ci, cppcheck, file1.c file2.c file3.h, -I/my/include/dir/inc)
 
 cppcheck_type_cfg:=$(ci_dir)/.cppcheck-types.cfg
 cppcheck_type_cfg_src:=$(ci_dir)/cppcheck-types.c
@@ -174,8 +174,7 @@ endef
 # @param1 space separated list of C source files
 # @param2 space separated list of C header files
 # @param3 a list of preprocessor flags, including header files root path
-# @param4 explicit space separated list of suppressions
-# @example $(call ci, misra, file1.c file2.c, file3.h)
+# @example $(call ci, misra, file1.c file2.c, file3.h, -I/my/include/dir/inc)
 
 misra_ci_dir:=$(ci_dir)/misra
 misra_rules:=$(misra_ci_dir)/rules.txt
@@ -219,7 +218,7 @@ $(misra_suppresions): $(misra_cppcheck_supressions) $(misra_deviation_suppressio
 	@cat $^ > $@
 
 misra-check: $(misra_rules) $(cppcheck_type_cfg) $(misra_suppresions)
-	@$(CPPCHECK) $(cppcheck_misra_flags) $(_misra_flags) $(_misra_c_files) $(_misra_sup)
+	@$(CPPCHECK) $(cppcheck_misra_flags) $(_misra_flags) $(_misra_c_files)
 
 misra-clean:
 	-rm -f $(misra_rules) $(misra_suppresions) $(misra_deviation_suppressions)
@@ -235,7 +234,6 @@ define misra
 _misra_c_files+=$1
 _misra_h_files+=$2
 _misra_flags+=$3
-_misra_sup+=$4
 endef
 
 #############################################################################


### PR DESCRIPTION
On partitioner-atf, the ci submodule cannot depend on the ATF definition of CPPFLAGS, since some compiler flags are
passed on this variable. This will make the checkers fail when called.
To solve this, each checker that needs the CPPFLAGS has now an extra parameter to be passed to the function call.

Signed-off-by: Daniel Oliveira <drawnpoetry@gmail.com>