### PR TITLE
feat(docker-checkers): add new sphinx checkers to the Dockerfile

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -22,8 +22,12 @@ RUN apt-get update && apt-get install -y \
         yamllint \
         pylint \
         clang-format-$CLANG_VERSION \
-        clang-tidy-$CLANG_VERSION && \
+        clang-tidy-$CLANG_VERSION \
+        nodejs npm && \
     pip3 install gitlint && \
+    pip3 install sphinxcontrib-spelling && \
+    pip3 install doc8 && \
+    npm install -g cspell@latest && \
     mkdir /opt/cppcheck && git clone $CPPCHECK_REPO --depth 1 /opt/cppcheck && make -C /opt/cppcheck FILESDIR=/usr/share/cppcheck && make -C /opt/cppcheck install FILESDIR=/usr/share/cppcheck  && \
     mkdir /opt/aarch64-toolchain && curl $AARCH64_TOOLCHAIN_LINK | tar xJ -C /opt/aarch64-toolchain --strip-components=1 && \
     mkdir /opt/riscv-toolchain && curl $RISCV_TOOLCHAIN_LINK | tar xz -C /opt/riscv-toolchain --strip-components=1

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -23,9 +23,14 @@ RUN apt-get update && apt-get install -y \
         pylint \
         clang-format-$CLANG_VERSION \
         clang-tidy-$CLANG_VERSION \
-        nodejs npm && \
+        nodejs \
+        npm \
+        enchant && \
     pip3 install gitlint && \
+    pip3 install pyenchant && \
     pip3 install sphinxcontrib-spelling && \
+    pip3 install sphinx-rtd-theme && \
+    pip3 install sphinx-tabs && \
     pip3 install doc8 && \
     npm install -g cspell@latest && \
     mkdir /opt/cppcheck && git clone $CPPCHECK_REPO --depth 1 /opt/cppcheck && make -C /opt/cppcheck FILESDIR=/usr/share/cppcheck && make -C /opt/cppcheck install FILESDIR=/usr/share/cppcheck  && \


### PR DESCRIPTION
To contemplate the new checkers to be used on CI, the Dockerfile had to be modified:

- doc8: style checker for reST documentation
- cspell: spell checker for code (requirements: npm, nodejs)
- sphinxcontrib-spelling: sphinx extension for spell cheking reST documentation (requirements: enchant, pyenchant)

Other non-checker related packages:
- sphinx-tabs: extension to be used on the documentation to enable interactive tabbed content
- sphinx-rtd-theme: sphinx theme

Note: the docker image has already been updated on docker-hub
