### PR TITLE
Fix: Add gitlint rule as a non build target

### DIFF
--- a/ci.mk
+++ b/ci.mk
@@ -16,6 +16,8 @@ CLANG-TIDY?=clang-tidy-$(CLANG_VERSION)
 gitlint:
 	@gitlint -C $(ci_dir)/.gitlint --commits $(GITLINT_BASE)..
 
+non_build_targets+=gitlint
+
 #############################################################################
 
 # License Checking


### PR DESCRIPTION
This is a quick fix to add gitlint rule as a non build target to prevent calling it with the PLATFORM argument.

Signed-off-by: Daniel Oliveira <drawnpoetry@gmail.com>