### PR TITLE
Add workflows for the ci repo itself

### DIFF
--- a/.github/workflows/base.yml
+++ b/.github/workflows/base.yml
@@ -1,0 +1,54 @@
+name: Bao ci base workflow
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+
+  gitlint:
+    runs-on: ubuntu-latest
+    container: baoproject/bao:latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          submodules: recursive
+          fetch-depth: 0
+      - run: >
+          git config --global --add safe.directory $(realpath .) &&
+          make gitlint GITLINT_BASE=${{ github.event.pull_request.base.sha }}
+
+  license:
+    runs-on: ubuntu-latest
+    container: baoproject/bao:latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          submodules: recursive
+          fetch-depth: 0
+      - run: >
+          make license-check
+
+  pylint:
+    runs-on: ubuntu-latest
+    container: baoproject/bao:latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          submodules: recursive
+          fetch-depth: 0
+      - run: >
+          make pylint
+
+  yamllint:
+    runs-on: ubuntu-latest
+    container: baoproject/bao:latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          submodules: recursive
+          fetch-depth: 0
+      - run: >
+          make yamllint

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,27 @@
+name: Build and Publish Bao Docker Container Image
+
+on:
+  push:
+    branches: [ master ]
+    paths: docker/Dockerfile
+
+jobs:
+
+  docker-build-publish-image:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          submodules: recursive
+          fetch-depth: 0
+      - uses: docker/setup-buildx-action@v1
+      - uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKERHUB_USER }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - uses: docker/build-push-action@v3
+        with:
+          context: .
+          file: ./docker/Dockerfile
+          push: true
+          tags: baoproj/bao:latest


### PR DESCRIPTION
This PR instantiates the base workflow which includes the gitlint, license, yamllint and pylint checks o these checks are also ran on PRs in the bao-ci repo itself.

Also it adds a workflow that automates the build and publishing of the docker image to Docker Hub if an accepted PR contains modifications to the Dockerfile. The Docker Hub login secrets (user name and token) were already created for the repository.