### PR TITLE
feat(gitlint): add update and opt tag to gitlint

### DIFF
--- a/.gitlint
+++ b/.gitlint
@@ -116,6 +116,6 @@ contrib=contrib-title-conventional-commits,CC1
 # You need to explicitly enable them one-by-one by adding them to the "contrib" option
 # under [general] section above.
 [contrib-title-conventional-commits]
-types = fix,ref,feat,build,doc,perf,wip,exp,test,ci,style
+types = fix,ref,feat,build,doc,perf,wip,exp,test,opt,ci,style,update
 
 [contrib-body-requires-signed-off-by]


### PR DESCRIPTION
This small PR introduces to the gitlint configuration file a new commit/branch type, namely `update`. Moreover, it also adds the `opt` tag already considered on the documentation.
* update:  changes that brings a feature, setup, or configuration up to date by adding new or updated information (e.g., updating a version, adding a new item to a list, updating CODEOWNERS, bumping the CI repo)
* opt: modifications pertaining only to optimizations 

bao-docs: https://github.com/bao-project/bao-docs/pull/24