### PR TITLE
update(codeowners): miguelafsilva5

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,2 @@
 # Maintainers
-* @josecm @AfonsoSantos96
+* @josecm @AfonsoSantos96 @miguelafsilva5


### PR DESCRIPTION
As @miguelafsilva5 is now a bao-ci maintainer, they must feature as a default code owner for the repo.

Signed-off-by: Jose Martins <josemartins90@gmail.com>