### PR TITLE
fix(workflows/docker): fix target branch name

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -2,7 +2,7 @@ name: Build and Publish Bao Docker Container Image
 
 on:
   push:
-    branches: [ master ]
+    branches: [ main ]
     paths: docker/Dockerfile
 
 jobs:


### PR DESCRIPTION
The workflow for publishing the docker image was not being triggered because the target branch name for which the workflow was dispatched was named 'master' instead of 'main'

Signed-off-by: Jose Martins <josemartins90@gmail.com>