### PR TITLE
fix(workflows/gitlint): use different base commit for different triggers

### DIFF
--- a/.github/workflows/base.yml
+++ b/.github/workflows/base.yml
@@ -14,11 +14,14 @@ jobs:
     steps:
       - uses: actions/checkout@v2
         with:
-          submodules: recursive
           fetch-depth: 0
-      - run: >
-          git config --global --add safe.directory $(realpath .) &&
-          make gitlint GITLINT_BASE=${{ github.event.pull_request.base.sha }}
+      - run: git config --global --add safe.directory $(realpath .)
+      - if: ${{ github.event_name == 'pull_request' }}
+        run: make gitlint GITLINT_BASE=${{ github.event.pull_request.base.sha }}
+      - if: ${{ github.event_name == 'push' }}
+        run: make gitlint GITLINT_BASE=${{ github.event.before }}
+      - if: ${{ github.event_name == 'workflow_dispatch' }}
+        run: make gitlint GITLINT_BASE=HEAD
 
   license:
     runs-on: ubuntu-latest

--- a/.github/workflows/templates/base.yml
+++ b/.github/workflows/templates/base.yml
@@ -14,11 +14,14 @@ jobs:
     steps:
       - uses: actions/checkout@v2
         with:
-          submodules: recursive
           fetch-depth: 0
-      - run: >
-          git config --global --add safe.directory $(realpath .) &&
-          make gitlint GITLINT_BASE=${{ github.event.pull_request.base.sha }}
+      - run: git config --global --add safe.directory $(realpath .)
+      - if: ${{ github.event_name == 'pull_request' }}
+        run: make gitlint GITLINT_BASE=${{ github.event.pull_request.base.sha }}
+      - if: ${{ github.event_name == 'push' }}
+        run: make gitlint GITLINT_BASE=${{ github.event.before }}
+      - if: ${{ github.event_name == 'workflow_dispatch' }}
+        run: make gitlint GITLINT_BASE=HEAD
 
   license:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Otherwise the check we fail if we are not on a PR, since 'github.event.pull_request.base.sha' is not defined when a workflow is triggered on a push to main or manually via workflow_dispatch.

Signed-off-by: Jose Martins <josemartins90@gmail.com>