### PR TITLE
fix(clang-version): Update clang-version in ci-mk

### DIFF
--- a/ci.mk
+++ b/ci.mk
@@ -5,7 +5,7 @@ ci_dir?=$(realpath $(root_dir)/ci)
 cur_dir:=$(realpath .)
 
 CPPCHECK?=cppcheck
-CLANG_VERSION?=12
+CLANG_VERSION?=14
 CLANG-FORMAT?=clang-format-$(CLANG_VERSION)
 CLANG-TIDY?=clang-tidy-$(CLANG_VERSION)
 


### PR DESCRIPTION
The clang-version in the ci.mk (CLANG_VERSION=12) does not match the clang-version in the docker image (CLANG_VERSION=14)

Signed-off-by: ESCristiano <cris96r@gmail.com>