### PR TITLE
feat/gh-templates: add templates for PRs/Issues and provision the repo with templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,27 @@
+---
+name: Bug report
+about: Create a report to help us improve
+title: "[BUG] add short description of bug"
+labels: bug
+assignees: ''
+
+---
+
+**Describe the bug**
+A clear and concise description of what the bug is.
+
+**To Reproduce**
+Steps to reproduce the behavior :
+1. Go to '...'
+2. Click on '....'
+3. Scroll down to '....'
+4. See error
+
+**Expected behavior**
+A clear and concise description of what you expected to happen.
+
+**Screenshots**
+If applicable, add screenshots to help explain your problem.
+
+**Additional context**
+Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,20 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+title: "[FEAT-REQ] add short description of the feat-request"
+labels: feature-request
+assignees: ''
+
+---
+
+**Is your feature request related to a problem? Please describe.**
+A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+
+**Describe the solution you'd like**
+A clear and concise description of what you want to happen.
+
+**Describe alternatives you've considered**
+A clear and concise description of any alternative solutions or features you've considered.
+
+**Additional context**
+Add any other context or screenshots about the feature request here.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -26,7 +26,7 @@ If your changes are included in the following categories, please try also to ans
 ### Type of change
 
 Before saving the PR, please delete this description and the below options that are not relevant.
-If you are not sure which type of change are you introducing, please read [Contributing](https://github.com/bao-project/bao-docs/blob/main/source/development/contributing.rst) documentation.
+If you are not sure which type of change are you introducing, please read [Contributing](https://github.com/bao-project/bao-docs/blob/main/source/development/doc_guidelines.rst) documentation.
 
 - **feat**: introduces a new functionality
   - Logical unit: <name>
@@ -45,17 +45,11 @@ If you are not sure which type of change are you introducing, please read [Contr
   - Test unit/suite: <name>
 - **opt**: modifications pertaining only to optimizations
   - Logical unit: <name>
-- **ci**: changes to the CI configuration files and scripts
-  - CI checker unit: <name>
 - **style**: changes that do not affect the meaning of the code (formatting, typos, naming, etc.)
 - **update**: changes that brings a feature, setup, or configuration up to date by adding new or updated information
   - Logical unit: <name>
 
 ## Checklist:
 
-- [ ] The changes follows the documentation guidelines described in [here](https://github.com/bao-project/bao-docs/blob/main/source/development/doc_guidelines.rst).
-- [ ] The changes follows the code documentation guidelines described in [here](https://github.com/bao-project/bao-docs/blob/main/source/development/code_documentation.rst).
-- [ ] The changes follows the coding style guidelines described in [here](https://github.com/bao-project/bao-docs/blob/main/source/development/coding_style.rst).
-- [ ] The changes follows the MISRA guidelines described in [here](https://github.com/bao-project/bao-docs/blob/main/source/development/misra.rst).
 - [ ] The changes generate no new warnings when building the project. If so, I have justified above.
 - [ ] I have run the CI checkers before submitting the PR to avoid unnecessary runs of the workflow.

--- a/.github/templates/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/templates/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,27 @@
+---
+name: Bug report
+about: Create a report to help us improve
+title: "[BUG] add short description of bug"
+labels: bug
+assignees: ''
+
+---
+
+**Describe the bug**
+A clear and concise description of what the bug is.
+
+**To Reproduce**
+Steps to reproduce the behavior :
+1. Go to '...'
+2. Click on '....'
+3. Scroll down to '....'
+4. See error
+
+**Expected behavior**
+A clear and concise description of what you expected to happen.
+
+**Screenshots**
+If applicable, add screenshots to help explain your problem.
+
+**Additional context**
+Add any other context about the problem here.

--- a/.github/templates/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/templates/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,20 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+title: "[FEAT-REQ] add short description of the feat-request"
+labels: feature-request
+assignees: ''
+
+---
+
+**Is your feature request related to a problem? Please describe.**
+A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+
+**Describe the solution you'd like**
+A clear and concise description of what you want to happen.
+
+**Describe alternatives you've considered**
+A clear and concise description of any alternative solutions or features you've considered.
+
+**Additional context**
+Add any other context or screenshots about the feature request here.

--- a/.github/templates/pull_request_template.md
+++ b/.github/templates/pull_request_template.md
@@ -1,0 +1,61 @@
+## PR Description
+
+Before saving the PR, please delete this description and add only your summary/description of the PR.
+Please include a summary of the change that tries to answer the following general questions:
+- What does this change introduces? Why is it required?
+- Which main blocks are affected?
+
+If your changes are included in the following categories, please try also to answer to these specific questions if they enhance your summary:
+- The PR changes introduces a new feature...
+  - What new feature is being introduced?
+  - Is the feature described in any of the requirements?
+- The PR changes solves a bug...
+  - What bug does it solve? What was the previous behavior/warning/error?
+  - Is the bug described in any issue ticket number?
+- The PR changes refactors a code/doc block...
+  - Why the code/doc block needed to be refactored?
+  - Is the improvement described in any issue ticket number?
+- The PR changes the build system...
+  - What building block of the build system was changed?
+  - Has any external dependency introduced?
+- The PR changes improves the overall performance of the system...
+  - Did you quantify the improvement on performance? Please share the numbers.
+- The PR changes adds new tests...
+  - What new tests were introduced or corrected?
+
+### Type of change
+
+Before saving the PR, please delete this description and the below options that are not relevant.
+If you are not sure which type of change are you introducing, please read [Contributing](https://github.com/bao-project/bao-docs/blob/main/source/development/contributing.rst) documentation.
+
+- **feat**: introduces a new functionality
+  - Logical unit: <name>
+- **fix**: bug fix
+  - Logical unit: <name>
+  - Fixes a specific issue: <#ticket-number>
+- **ref**: refactoring of a code/doc block
+  - Logical unit: <name>
+- **build**: changes that affect the build system or external dependencies
+  - Logical unit: <name>
+- **doc**: documentation only changes
+  - Files affected: <name>
+- **perf**: a code change that improves performance
+  - Logical unit: <name>
+- **test**: adding missing tests or correcting existing ones
+  - Test unit/suite: <name>
+- **opt**: modifications pertaining only to optimizations
+  - Logical unit: <name>
+- **ci**: changes to the CI configuration files and scripts
+  - CI checker unit: <name>
+- **style**: changes that do not affect the meaning of the code (formatting, typos, naming, etc.)
+- **update**: changes that brings a feature, setup, or configuration up to date by adding new or updated information
+  - Logical unit: <name>
+
+## Checklist:
+
+- [ ] The changes follows the documentation guidelines described in [here](https://github.com/bao-project/bao-docs/blob/main/source/development/doc_guidelines.rst).
+- [ ] The changes follows the code documentation guidelines described in [here](https://github.com/bao-project/bao-docs/blob/main/source/development/code_documentation.rst).
+- [ ] The changes follows the coding style guidelines described in [here](https://github.com/bao-project/bao-docs/blob/main/source/development/coding_style.rst).
+- [ ] The changes follows the MISRA guidelines described in [here](https://github.com/bao-project/bao-docs/blob/main/source/development/misra.rst).
+- [ ] The changes generate no new warnings when building the project. If so, I have justified above.
+- [ ] I have run the CI checkers before submitting the PR to avoid unnecessary runs of the workflow.


### PR DESCRIPTION
## PR Description

This change adds a PR and issues template for the bao-ci repository. Moreover, a new folder has created in `.github/templates` to aggregate general templates to be used by other @bao-project/maintainers  on their own repos. Please use them on your own repos, after this PR is introduced.

### Type of change

- **feat**: introduces a new functionality
  - Logical unit: PR and Issues templates

## Checklist:

- [x] The changes generate no new warnings when building the project. If so, I have justified above.
- [x] I have run the CI checkers before submitting the PR to avoid unnecessary runs of the workflow.
