### PR TITLE
fix: correctly invoke compiler in misra rule

### DIFF
--- a/ci.mk
+++ b/ci.mk
@@ -146,7 +146,7 @@ cppcheck_type_cfg:=$(ci_dir)/.cppcheck-types.cfg
 cppcheck_type_cfg_src:=$(ci_dir)/cppcheck-types.c
 
 $(cppcheck_type_cfg): $(cppcheck_type_cfg_src)
-	@$(cc) -S -o - $< | grep "\->" | sed -r 's/.*->//g' > $@
+	@$(CC) -S -o - $< | grep "\->" | sed -r 's/.*->//g' > $@
 
 cppcheck_suppressions:=$(ci_dir)/.cppcheck-suppress
 cppcheck_flags:= --quiet --enable=all --error-exitcode=1 \


### PR DESCRIPTION
Fix a Makefile rule error in generating the `.cppcheck-types.cfg` file, by correctly invoking the c compiler.
Before this fix, make would not correctly generate `.cppcheck-types.cfg` file, preventing it from running the misra-check rule successfully.
This error affects the misra makefile rules, misra-check in particular.