### PR TITLE
Revert "fix: correctly invoke compiler in misra rule"

### DIFF
--- a/ci.mk
+++ b/ci.mk
@@ -146,7 +146,7 @@ cppcheck_type_cfg:=$(ci_dir)/.cppcheck-types.cfg
 cppcheck_type_cfg_src:=$(ci_dir)/cppcheck-types.c
 
 $(cppcheck_type_cfg): $(cppcheck_type_cfg_src)
-	@$(CC) -S -o - $< | grep "\->" | sed -r 's/.*->//g' > $@
+	@$(cc) -S -o - $< | grep "\->" | sed -r 's/.*->//g' > $@
 
 cppcheck_suppressions:=$(ci_dir)/.cppcheck-suppress
 cppcheck_flags:= --quiet --enable=all --error-exitcode=1 \


### PR DESCRIPTION
Reverts bao-project/bao-ci#30

The problem was really non-existent. @DavidMCerdeira was including ci.mk in a Makefile where `cc` was not defined. In the future we should clearly document and call attention to what variables must be defined before including ci.mk