### PR TITLE
feat(docker): always check latest docker image

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,18 @@ If you prefer, you can build the container image locally by running:
 make -C ci/docker build
 ```
 
+---
+
+**NOTE**
+
+The provided Makefile always checks Docker Hub for an updated container
+image. If you are not using it to start the container please make sure the
+image is indeed up to date with the latest Dockefile either by pulling it
+expliclity (i.e. `docker pull baoproject/bao:latest`) or by bulding it yourself
+locally.
+
+---
+
 ## Setting up GitHub Actions
 
 When setting up GitHub Actions' workflows for you repo, each step should make

--- a/docker/Makefile
+++ b/docker/Makefile
@@ -24,7 +24,7 @@ override MAKEFLAGS:=$(addprefix -,$(MAKEFLAGS)) --no-print-directory
 
 all .DEFAULT:
 	@echo "Launching docker container..."
-	-@$(DOCKER) run --rm -it -u bao -v $(root_dir):$(root_dir) -w $(root_dir) \
+	-@$(DOCKER) run --pull=always --rm -it -u bao -v $(root_dir):$(root_dir) -w $(root_dir) \
 		$(docker_image) $(MAKE) $(MAKEFLAGS) $(MAKEOVERRIDES) $@
 	@echo "Leaving and destroying docker container..."
 


### PR DESCRIPTION
Signed-off-by: Jose Martins <josemartins90@gmail.com>

## PR Description

When using the [docker Makefile](https://github.com/bao-project/bao-ci/blob/ed64185520b6e4e243edbe183cd1de771e3b50c7/docker/Makefile) to run the container, it will build and/or fetch the image using the `latest` tag. The [docker worflow](https://github.com/bao-project/bao-ci/blob/main/.github/workflows/docker.yml) will also publish the updated container image to Docker Hub always using the same tag. So, if in a given commit the [Dockerfile](https://github.com/bao-project/bao-ci/blob/ed64185520b6e4e243edbe183cd1de771e3b50c7/docker/Dockerfile) is updated, a less attentive user that already had a container image locally may not notice the change and keep running the same image they had previously fetched or built.

This PR updates the [docker Makefile](https://github.com/bao-project/bao-ci/blob/ed64185520b6e4e243edbe183cd1de771e3b50c7/docker/Makefile) `run` recipe to always try to pull the latest container image version, and updates the instructions in the README.md file to alert users to the issue.

### Type of change

- **feat**: introduces a new functionality
  - Logical unit: docker

## Checklist:

- [x] Change docker/Makefile run recipe to always pull the latest image available on Docker Hub.
- [x] Update README.md Docker instructions to make alter users to make sure the docker image is updated before using it.
