### PR TITLE
fix: erase temporary .clang_format

### DIFF
--- a/ci.mk
+++ b/ci.mk
@@ -92,18 +92,15 @@ $(format_file): $(original_format_file)
 	@cp $< $@
 
 format: $(format_file)
-	@$(CLANG-FORMAT) $(clang_format_flags) -i $(_format_files)
+	@$(CLANG-FORMAT) $(clang_format_flags) -i $(_format_files); \
+	rm $(format_file)
 
 format-check: $(format_file)
-	@diff <(cat $(_format_files)) <($(CLANG-FORMAT) $(clang_format_flags) $(_format_files))
+	@diff <(cat $(_format_files)) <($(CLANG-FORMAT) $(clang_format_flags) $(_format_files)); \
+	rm $(format_file)
 
-format-clean:
-	-@rm -f $(format_file)
-
-clean: format-clean
-
-.PHONY: format format-check format-clean
-non_build_targets+=format format-check format-clean
+.PHONY: format format-check
+non_build_targets+=format format-check
 
 define format
 _format_files+=$1


### PR DESCRIPTION
## PR Description

The .clang_format file is copied to the current working directory each time one of the 'format' or 'format-check' rules are run, because the clang-format tool needs this configuration file to be in the same directory it is executed.

Previously there was a format-clean rule that would erase this file, but it is more user-friendly to erase it every time after the commands are executed. Otherwise, a user might neglect to call 'clean' and mistake the file for a file in the repo and add it in a commit.

### Type of change

This PR introduces a bug fix in the sense that leaving the stale clang-format file behind, which could be introduced in a commit by an inattentive developer, could result in the format rules using outdated configurations.

  - Logical unit: ci.mk, format rules