### PR TITLE
Check for variables that must defined in ci.mk

### DIFF
--- a/ci.mk
+++ b/ci.mk
@@ -1,8 +1,13 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright (c) Bao Project and Contributors. All rights reserved
 
+$(call check_variable_defined, root_dir, \
+	"To include ci.mk the 'root_dir' must be defined")
+
 ci_dir?=$(realpath $(root_dir)/ci)
 cur_dir:=$(realpath .)
+
+include $(ci_dir)/util.mk
 
 CPPCHECK?=cppcheck
 CLANG_VERSION?=14
@@ -138,6 +143,8 @@ endef
 # Cppcheck static-analyzer
 # Run it by:
 #    make cppcheck
+# @pre the make variable 'cc' must be defined with the target's cross-compiler
+#	to run any cppcheck-based rules
 # @param files a single space-separated list of C files (header or source)
 # @param headers a list of preprocessor flags, including header files root path
 # @example $(call ci, cppcheck, file1.c file2.c file3.h, -I/my/include/dir/inc)
@@ -165,6 +172,8 @@ clean: cppcheck-clean
 non_build_targets+=cppcheck cppcheck-clean
 
 define cppcheck
+$(call check_variable_defined, cc, \
+	"For running cppcheck-based tests 'cc' must be defined")
 _cppcheck_files+=$1
 _cppcheck_flags+=$2
 endef

--- a/util.mk
+++ b/util.mk
@@ -1,0 +1,10 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) Bao Project and Contributors. All rights reserved
+
+# Check if a given variable is defined.
+# @param variable name
+# @param error message (optional)
+# @example $(call check_variable_defined, XPTO, "The XPTO must be defined!")
+define check_variable_defined
+$(if $($(strip $1)),,$(error $(strip $1) not defined: $(strip $2)))
+endef


### PR DESCRIPTION
## PR Description

As pointed out in #32, certain variables such as 'cc' must be defined by the Makefile that instantiates certain CI rules. There was no measure put in place to check that these variables were indeed defined. This PR introduces these checks by:

- Creating an utility function that checks if the argument variable is defined;
- Adding the check for the 'root_dir' variable which must be defined before ci.mk is included;
- Adding the check for the 'cc' variable that must be defined when the 'cppcheck' rules are instantiated.
