### PR TITLE
style(lic-checker): change print of abs path to only rel path

### DIFF
--- a/license_check.py
+++ b/license_check.py
@@ -7,6 +7,7 @@
 Check for SPDX license headers and copyright notice in source files
 """
 
+import os
 import sys
 import re
 import argparse
@@ -35,7 +36,7 @@ def check_copyright(filename, copyright_notice):
             if copyright_notice in line:
                 return True
 
-        eprint(f'No copyright notice found in {filename}')
+        eprint(f'Copyright not found in ...\t\t{filename}')
         return False
 
 
@@ -43,7 +44,7 @@ def check_license(filename, spdx_expr):
 
     """Check if 'filename' has a SPDX identifier complying with 'spdx_exr'"""
 
-    # TODO: improve regex to support multiple licenses (AND, OR) and execeptions (WITH)
+    # TODO: improve regex to support multiple licenses (AND, OR) and exceptions (WITH)
     spdx_regex = r'SPDX-License-Identifier: \(?(?P<license_expr>\S*)\)?'
 
     try:
@@ -81,7 +82,7 @@ def check_license(filename, spdx_expr):
 
                 return True
 
-    eprint(f'License not found in {filename}')
+    eprint(f'License not found in ...\t\t{filename}')
     return False
 
 
@@ -121,8 +122,11 @@ def main():
 
     success = True
     for file in args.file:
-        success = check_license(file, spdx_expr) and success
-        success = check_copyright(file, copyright_notice) and success
+
+        rel_path = os.path.relpath(file, os.getcwd())
+
+        success = check_license(rel_path, spdx_expr) and success
+        success = check_copyright(rel_path, copyright_notice) and success
 
     if not success:
         sys.exit(-1)

--- a/license_check.py
+++ b/license_check.py
@@ -36,7 +36,7 @@ def check_copyright(filename, copyright_notice):
             if copyright_notice in line:
                 return True
 
-        eprint(f'Copyright not found in ...\t\t{filename}')
+        eprint(f'Copyright not found: \t\t{filename}')
         return False
 
 
@@ -82,7 +82,7 @@ def check_license(filename, spdx_expr):
 
                 return True
 
-    eprint(f'License not found in ...\t\t{filename}')
+    eprint(f'License not found: \t\t{filename}')
     return False
 
 
@@ -106,7 +106,6 @@ def main():
     spdx_expr = args.license
     if not spdx_expr:
         spdx_expr = 'Apache-2.0'
-        eprint(f'No SPDX expression supplied. Using {spdx_expr}.')
     spdx_expr_info = spdx_parser.validate(spdx_expr)
     if spdx_expr_info.errors:
         eprint('Invalid supplied SPDX expression\':')
@@ -118,7 +117,6 @@ def main():
     copyright_notice = args.copyright
     if not copyright_notice:
         copyright_notice = "Copyright (c) Bao Project and Contributors. All rights reserved"
-        eprint(f'No copyright notice supplied. Using {copyright_notice}.')
 
     success = True
     for file in args.file:


### PR DESCRIPTION
## PR Description

Small style changes on the output of the `license_checker.py` script to prevent the output of the absolute path of the file being parsed, which can make it to confusing.

### Type of change

- **style**: changes that do not affect the meaning of the code (formatting, typos, naming, etc.)

## Checklist:

- [x] The changes generate no new warnings when building the project. If so, I have justified above.
- [x] I have run the CI checkers before submitting the PR to avoid unnecessary runs of the workflow.
