### PR TITLE
fix(clang-format): point directly to .clang-format config file

### DIFF
--- a/ci.mk
+++ b/ci.mk
@@ -84,26 +84,17 @@ endef
 # @param space-separated list of C source or header files
 # @example $(call ci, format, file1.c fil2.c file3.h)
 
-clang_format_flags:=--style=file
-format_file:=$(cur_dir)/.clang-format
-original_format_file:=$(ci_dir)/.clang-format
+format_file:=$(ci_dir)/.clang-format
+clang_format_flags:=--style=file:$(format_file)
 
-$(format_file): $(original_format_file)
-	@cp $< $@
-
-format: $(format_file)
+format:
 	@$(CLANG-FORMAT) $(clang_format_flags) -i $(_format_files)
 
-format-check: $(format_file)
+format-check:
 	@diff <(cat $(_format_files)) <($(CLANG-FORMAT) $(clang_format_flags) $(_format_files))
 
-format-clean:
-	-@rm -f $(format_file)
-
-clean: format-clean
-
-.PHONY: format format-check format-clean
-non_build_targets+=format format-check format-clean
+.PHONY: format format-check
+non_build_targets+=format format-check
 
 define format
 _format_files+=$1


### PR DESCRIPTION
## PR Description

This PR changes the way the clang-format rule locates the configuration file by directly pointing to it instead of relying on its relative position in the project directory structure.

In previous clang versions  '.clang-format' file had to be located " located in one of the parent directories of the source file (or current directory for stdin).", which made us have to copy the file to the root of the project we were analyzing. In clang-format-14 it is possible to directly point to it by defining the option '-style=file:/path/to/.clang-format'.

@DavidMCerdeira  suggested this in #36 

### Type of change

In essence, this PR *fixes* the way the .clang-format file is located.

## Checklist:

- [x] I have run the CI checkers before submitting the PR to avoid unnecessary runs of the workflow.
