### PR TITLE
feat: Add spellchecking python library

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -38,6 +38,7 @@ RUN apt-get update && apt-get install -y \
     pip3 install psutil && \
     pip3 install pyserial && \
     pip3 install doorstop && \
+    pip3 install pyspellchecker && \
     npm install -g cspell@latest && \
     mkdir /opt/cppcheck && git clone $CPPCHECK_REPO --depth 1 --branch $CPPCHECK_VERSION /opt/cppcheck && make -C /opt/cppcheck FILESDIR=/usr/share/cppcheck && make -C /opt/cppcheck install FILESDIR=/usr/share/cppcheck  && \
     mkdir /opt/aarch64-toolchain && curl $AARCH64_TOOLCHAIN_LINK | tar xJ -C /opt/aarch64-toolchain --strip-components=1 && \


### PR DESCRIPTION
Add the pyspellchecker python library to dockerfile.
The pyspellchecker python library is used to implement our own spellchecking scripts.

