### PR TITLE
fix: Use correct tag in docker build and publish workflow

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -24,4 +24,4 @@ jobs:
           context: .
           file: ./docker/Dockerfile
           push: true
-          tags: baoproj/bao:latest
+          tags: baoproject/bao:latest


### PR DESCRIPTION
The current docker build and publish workflow uses baoproj instead of baoproject tag.
This results in an error that prevents the workflow from publishing a newly built docker to dockerhub.
To fix this, the commit updates the appropriate field in .github/workflows/docker.yml
