### PR TITLE
feat(docker): add ropgadget, capstone, gitpython libraries

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -39,6 +39,9 @@ RUN apt-get update && apt-get install -y \
     pip3 install pyserial && \
     pip3 install doorstop && \
     pip3 install pyspellchecker && \
+    pip3 install ROPgadget && \
+    pip3 install capstone && \
+    pip3 install GitPython && \
     npm install -g cspell@latest && \
     mkdir /opt/cppcheck && git clone $CPPCHECK_REPO --depth 1 --branch $CPPCHECK_VERSION /opt/cppcheck && make -C /opt/cppcheck FILESDIR=/usr/share/cppcheck && make -C /opt/cppcheck install FILESDIR=/usr/share/cppcheck  && \
     mkdir /opt/aarch64-toolchain && curl $AARCH64_TOOLCHAIN_LINK | tar xJ -C /opt/aarch64-toolchain --strip-components=1 && \


### PR DESCRIPTION
## PR Description

Add the ropgadget, capstone and gitpyhton python libraries to dockerfile.
These libraries are used by the `rop_gadget` checker. 

### Type of change

- **feat**: introduces a new functionality
  - Logical unit: dockerfile

## Checklist:

- [X] The changes generate no new warnings when building the project. If so, I have justified above.
- [X] I have run the CI checkers before submitting the PR to avoid unnecessary runs of the workflow.
