### PR TITLE
feat/doc8: add checker to ci.mk

### DIFF
--- a/.github/workflows/templates/misc.yaml
+++ b/.github/workflows/templates/misc.yaml
@@ -29,3 +29,13 @@ jobs:
           fetch-depth: 0
       - run: >
           make yamllint
+
+  docformat:
+    runs-on: ubuntu-latest
+    container: baoproject/bao:latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+          submodules: recursive
+      - run: make rst-format

--- a/ci.mk
+++ b/ci.mk
@@ -340,5 +340,22 @@ endef
 
 #############################################################################
 
-ci=$(eval $(call $1, $2, $3, $4, $5, $6, $7, $8, $9))
+# reST Formatting
+# Provides one make target:
+#    make rst-format # checks if the provided reST files are formated correctly
+# @param root folder that contains the reST files
+# @example $(call ci, rstformat, /path/to/doc/folder)
 
+rst-format:
+	@doc8 $(_path_rst_files) --ignore D000
+
+.PHONY: rst-format
+non_build_targets+=rst-format
+
+define rstformat
+_path_rst_files+=$1
+endef
+
+#############################################################################
+
+ci=$(eval $(call $1, $2, $3, $4, $5, $6, $7, $8, $9))


### PR DESCRIPTION
## PR Description

This PR comes in segment with the PR https://github.com/bao-project/bao-docs/pull/68. It adds the ``doc8`` style checker to ``ci.mk`` and a github action on templates to run it.

### Type of change

- **feat**: introduces a new functionality
  - Logical unit: <ci-mk>

## Checklist:

- [x] The changes generate no new warnings when building the project. If so, I have justified above.
- [x] I have run the CI checkers before submitting the PR to avoid unnecessary runs of the workflow.
