### PR TITLE
feat(ci.mk): allow inclusion before 'all' target

### DIFF
--- a/ci.mk
+++ b/ci.mk
@@ -14,6 +14,8 @@ CLANG_VERSION?=14
 CLANG-FORMAT?=clang-format-$(CLANG_VERSION)
 CLANG-TIDY?=clang-tidy-$(CLANG_VERSION)
 
+all:
+
 .SECONDEXPANSION:
 
 #############################################################################


### PR DESCRIPTION
This modification allows the inclusion of *ci.mk* before the definition of the first Makefile target, which is assumes is `all`, the typical Makefile convention.
