### PR TITLE
Update clang tools version in docker and .clang-format options

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -9,9 +9,8 @@ AlignConsecutiveBitFields: None
 AlignConsecutiveDeclarations: None
 AlignEscapedNewlines: Left
 AlignOperands: DontAlign
-AlignTrailingComments: true
+AlignTrailingComments: false
 AllowAllArgumentsOnNextLine: false
-AllowAllConstructorInitializersOnNextLine: true
 AllowAllParametersOfDeclarationOnNextLine: false
 AllowShortEnumsOnASingleLine: true
 AllowShortBlocksOnASingleLine: Always
@@ -39,25 +38,26 @@ BraceWrapping:
   SplitEmptyRecord: false
 BreakBeforeBinaryOperators: None
 BreakBeforeTernaryOperators: false
+BreakBeforeInlineASMColon: OnlyMultiline
 BreakStringLiterals: true 
 ColumnLimit:     80
 ContinuationIndentWidth: 4
-DeriveLineEnding: true
 DerivePointerAlignment: false
 DisableFormat: false
 ExperimentalAutoDetectBinPacking: false
-ForEachMacros:
-  - foreach
-  - Q_FOREACH
-  - BOOST_FOREACH
 IncludeBlocks: Preserve
 IndentCaseBlocks: false
 IndentCaseLabels: true
 IndentGotoLabels: false
-IndentPPDirectives: None
+IndentPPDirectives: BeforeHash
 IndentWidth:     4
 IndentWrappedFunctionNames: false
+InsertBraces: true  
+InsertNewlineAtEOF: true
+InsertTrailingCommas: None
+KeepEmptyLinesAtEOF: false
 KeepEmptyLinesAtTheStartOfBlocks: false
+LineEnding: LF
 MacroBlockBegin: ''
 MacroBlockEnd:   ''
 MaxEmptyLinesToKeep: 1
@@ -65,12 +65,22 @@ PenaltyBreakAssignment: 2
 PenaltyBreakBeforeFirstCallParameter: 1000
 PenaltyBreakComment: 10
 PenaltyBreakFirstLessLess: 10
+PenaltyBreakOpenParenthesis: 5
 PenaltyBreakString: 10
 PenaltyBreakTemplateDeclaration: 10
-PenaltyExcessCharacter: 100
+PenaltyExcessCharacter: 50
 PenaltyReturnTypeOnItsOwnLine: 100
 PointerAlignment: Left
+# Not using QualigierAlignment as it seems only to affect parameter lists, not
+# variable declarations. May enable it if this changes in future clang-format
+# versions.
+# QualifierAlignment: Custom
+# QualifierOrder: ['static', 'inline', 'type', 'const', 'volatile']
 ReflowComments:  true
+RemoveBracesLLVM: false
+RemoveParentheses: MultipleParentheses
+RemoveSemicolon: true
+SeparateDefinitionBlocks: Leave
 SortIncludes: false
 SpaceAfterCStyleCast: false
 SpaceAfterLogicalNot: false
@@ -80,11 +90,13 @@ SpaceBeforeInheritanceColon: true
 SpaceBeforeParens: ControlStatements
 SpaceBeforeRangeBasedForLoopColon: false
 SpaceInEmptyBlock: true
-SpaceInEmptyParentheses: false
+SpacesInParens: Custom
+SpacesInParensOptions:
+    InConditionalStatements: false
+    InEmptyParentheses: false
+    InCStyleCasts: false
+    Other: false
 SpacesBeforeTrailingComments: 1
-SpacesInConditionalStatement: false
-SpacesInCStyleCastParentheses: false
-SpacesInParentheses: false
 SpacesInSquareBrackets: false
 SpaceBeforeSquareBrackets: false
 Standard:        Latest
@@ -92,7 +104,6 @@ StatementMacros:
   - Q_UNUSED
   - QT_REQUIRE_VERSION
 TabWidth:        4
-UseCRLF:         false
 UseTab:          Never
 WhitespaceSensitiveMacros:
   - STRINGIZE

--- a/ci.mk
+++ b/ci.mk
@@ -10,7 +10,7 @@ cur_dir:=$(realpath .)
 include $(ci_dir)/util.mk
 
 CPPCHECK?=cppcheck
-CLANG_VERSION?=14
+CLANG_VERSION?=18
 CLANG-FORMAT?=clang-format-$(CLANG_VERSION)
 CLANG-TIDY?=clang-tidy-$(CLANG_VERSION)
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -7,7 +7,7 @@ ARG AARCH64_TOOLCHAIN_LINK=https://armkeil.blob.core.windows.net/developer/Files
 ARG AARCH32_TOOLCHAIN_LINK=https://armkeil.blob.core.windows.net/developer/Files/downloads/gnu/12.3.rel1/binrel/arm-gnu-toolchain-12.3.rel1-x86_64-arm-none-eabi.tar.xz
 ARG RISCV_TOOLCHAIN_LINK=https://static.dev.sifive.com/dev-tools/freedom-tools/v2020.12/riscv64-unknown-elf-toolchain-10.2.0-2020.12.8-x86_64-linux-ubuntu14.tar.gz
 ARG ASMFMT_LINK=https://github.com/klauspost/asmfmt/releases/download/v1.3.2/asmfmt-Linux_x86_64_1.3.2.tar.gz
-ARG CLANG_VERSION=14
+ARG CLANG_VERSION=18
 # use this repo temporarily while the patches for misra fps are not in a new official version
 ARG CPPCHECK_REPO=https://github.com/danmar/cppcheck.git
 ARG CPPCHECK_VERSION=2.9
@@ -52,7 +52,9 @@ RUN npm install -g cspell@latest
 
 # Install static analyzers
 # clang-format and clang-tidy
-RUN apt-get install -y \
+RUN wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add - && \
+    add-apt-repository 'deb http://apt.llvm.org/jammy/ llvm-toolchain-jammy main' && \
+    apt-get update && apt-get install -y \
         clang-format-$CLANG_VERSION \
         clang-tidy-$CLANG_VERSION
 # cppcheck


### PR DESCRIPTION
This PR updates clang-tidy and clang-format tools to version 18 and also the .clang-format file with the newly available options for formatting.

This PR depends on #60.