### PR TITLE
feat(qemu): add support for qemu-aarch64 and qemu-riscv64 in Docker

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -78,6 +78,11 @@ RUN mkdir /opt/aarch64-toolchain && curl $AARCH64_TOOLCHAIN_LINK | tar xJ -C /op
 # Add generic non-root user
 RUN addgroup bao && adduser -disabled-password --ingroup bao bao
 
+# Add qemu-riscv64-virt
+RUN git clone https://github.com/qemu/qemu.git /opt/qemu-riscv64-virt --depth 1 --branch v7.2.0 && \
+    cd /opt/qemu-riscv64-virt/ && ./configure --target-list=riscv64-softmmu --enable-slirp && \
+    make -j$(nproc) && \
+    make install
 # setup environment
 ENV PATH=$PATH:/opt/aarch64-toolchain/bin
 ENV PATH=$PATH:/opt/aarch32-toolchain/bin

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -27,7 +27,14 @@ RUN apt-get update && apt-get install -y \
         nodejs \
         npm \
         enchant-2 \
-        software-properties-common
+        software-properties-common \
+        ninja-build \
+        pkg-config \
+        libglib2.0-dev \
+        libpixman-1-dev \
+        libslirp-dev \
+        bison \
+        flex \
 
 # Install python packages
 RUN pip3 install \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -83,6 +83,13 @@ RUN git clone https://github.com/qemu/qemu.git /opt/qemu-riscv64-virt --depth 1 
     cd /opt/qemu-riscv64-virt/ && ./configure --target-list=riscv64-softmmu --enable-slirp && \
     make -j$(nproc) && \
     make install
+
+# Add qemu-aarch64-virt
+RUN git clone https://github.com/qemu/qemu.git /opt/qemu-aarch64-virt --depth 1 --branch v7.2.0 && \
+    cd /opt/qemu-aarch64-virt && ./configure --target-list=aarch64-softmmu --enable-slirp && \
+    make -j$(nproc) && \
+    make install
+
 # setup environment
 ENV PATH=$PATH:/opt/aarch64-toolchain/bin
 ENV PATH=$PATH:/opt/aarch32-toolchain/bin

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -35,6 +35,9 @@ RUN apt-get update && apt-get install -y \
         libslirp-dev \
         bison \
         flex \
+        tree \
+        vim \
+        nano
 
 # Install python packages
 RUN pip3 install \


### PR DESCRIPTION
## PR Description

This PR implements the necessary changes to the Dockerfile, enabling support for both aarch64 and risc-v versions of qemu. The updates encompass the following changes:

1. Updated base dependencies required for building qemu (commit https://github.com/bao-project/bao-ci/pull/73/commits/96be375d352c211e8e9dbb38de8e042df7a3ef73);
2. Addded installation steps for qemu-riscv64 (commit https://github.com/bao-project/bao-ci/pull/73/commits/da9edbe4d02e8685333db92ba6f605989876d8f0);
3. Included installation steps for qemu-aarch64 (commit https://github.com/bao-project/bao-ci/pull/73/commits/deb712e272fa1c875c2bb2631cd18e955dce0995).


Aditionally, commit https://github.com/bao-project/bao-ci/pull/73/commits/7a83e9bf78f1b1f65285c18ea31c2a549f0a3a5c introduces utility commands, including the `tree` command, as well as two text editors, `vim` and `nano`.



## Checklist:

- [x] The changes generate no new warnings when building the project. If so, I have justified above.
- [x] I have run the CI checkers before submitting the PR to avoid unnecessary runs of the workflow.
