### PR TITLE
fix(format): revert back clang version to 18

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -7,7 +7,7 @@ ARG AARCH64_TOOLCHAIN_LINK=https://armkeil.blob.core.windows.net/developer/Files
 ARG AARCH32_TOOLCHAIN_LINK=https://armkeil.blob.core.windows.net/developer/Files/downloads/gnu/13.2.rel1/binrel/arm-gnu-toolchain-13.2.rel1-x86_64-arm-none-eabi.tar.xz
 ARG RISCV_TOOLCHAIN_LINK=https://static.dev.sifive.com/dev-tools/freedom-tools/v2020.12/riscv64-unknown-elf-toolchain-10.2.0-2020.12.8-x86_64-linux-ubuntu14.tar.gz
 ARG ASMFMT_LINK=https://github.com/klauspost/asmfmt/releases/download/v1.3.2/asmfmt-Linux_x86_64_1.3.2.tar.gz
-ARG CLANG_VERSION=19
+ARG CLANG_VERSION=18
 # use this repo temporarily while the patches for misra fps are not in a new official version
 ARG CPPCHECK_REPO=https://github.com/danmar/cppcheck.git
 ARG CPPCHECK_VERSION=2.9
@@ -64,7 +64,7 @@ RUN npm install -g cspell@latest
 # Install static analyzers
 # clang-format and clang-tidy
 RUN wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add - && \
-    add-apt-repository 'deb http://apt.llvm.org/jammy/ llvm-toolchain-jammy main' && \
+    add-apt-repository 'deb http://apt.llvm.org/jammy/ llvm-toolchain-jammy-$(CLANG_VERSION) main' && \
     apt-get update && apt-get install -y \
         clang-format-$CLANG_VERSION \
         clang-tidy-$CLANG_VERSION


### PR DESCRIPTION
clang-format-19 introduces format unwanted format changes with no way to fix them in a scalable manner. We will wait for version 20 to understand if this issue is fixed.