### PR TITLE
fix(docker): Fix docker makefile variable

### DIFF
--- a/docker/Makefile
+++ b/docker/Makefile
@@ -12,7 +12,7 @@ ifeq ($(DOCKER_PULL),y)
 docker_pull_option:=--pull=always
 endif
 docker_run_cmd:=$(DOCKER) run $(docker_pull_option) --rm -it -u bao -v \
-	$(root_dir):$(root_dir) -w $(root_dir) $(docker_image)
+	$(ROOT_DIR):$(ROOT_DIR) -w $(ROOT_DIR) $(docker_image)
 
 override MAKEFLAGS:=$(addprefix -,$(MAKEFLAGS)) --no-print-directory
 


### PR DESCRIPTION
Fix an issue where commands such as `make -C ci/docker format` do not execute, by setting a consistent capitalization for ROOT_DIR variable in the docker Makefile.