### PR TITLE
feat(doxygen): Add doxygen in ci

### DIFF
--- a/ci.mk
+++ b/ci.mk
@@ -65,7 +65,7 @@ endef
 #############################################################################
 
 # Python linting
-# Checks if the provided python scrpits for syntax and format:
+# Checks if the provided python scripts for syntax and format:
 #    make pylint
 # @param space-separated list of python files
 # @example $(call ci, pylint, file1.py file2.py)
@@ -356,6 +356,25 @@ non_build_targets+=rst-format
 
 define rstformat
 _path_rst_files+=$1
+endef
+
+#############################################################################
+
+# Doxygen build
+# Loads the Doxyfile stored in the current directory, parses the source files
+# and produces a documentation of the codebase, according to its configuration.
+# @param	Doxygen configuration file (Doxyfile).
+#			If not provided, a Doxyfile in the current working directory is used.
+# @note For details, see doxygen manual at https://www.doxygen.nl/manual/index.html.
+
+doxygen:
+	@doxygen $(_doxygen_doxyfile)
+
+.PHONY: doxygen
+non_build_targets+=doxygen
+
+define doxygen
+_doxygen_doxyfile+=$1
 endef
 
 #############################################################################

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -44,7 +44,8 @@ RUN apt-get update && apt-get install -y \
         nano \
         device-tree-compiler \
         gawk \
-        libgnutls28-dev
+        libgnutls28-dev \
+        doxygen
 
 # Install python packages
 RUN pip3 install \


### PR DESCRIPTION
## PR Description

The changes introduce the doxygen recipe in the CI, allowing doxygen to be run.
Running doxygen allows to catch format errors and undocumented/incomplete documentation, according to the rules set in the projects' Doxyfile.

The parts affected by this change are
- `ci.mk` (doxygen recipe); and
- `Dockerfile`, which requires the addition of doxygen to the `apt-get install` command.

## Checklist:

- [x] The changes generate no new warnings when building the project. If so, I have justified above.
- [x] I have run the CI checkers before submitting the PR to avoid unnecessary runs of the workflow.